### PR TITLE
Use default tmpdir for temporary files

### DIFF
--- a/src/runner.go
+++ b/src/runner.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -59,7 +58,7 @@ func startScript(ctx context.Context, d *pb.Data, s *jobStorage) {
 		job.EffectiveUser = &effectiveUser
 	}
 
-	scriptfile, err := ioutil.TempFile("/tmp", "ygg_rex")
+	scriptfile, err := os.CreateTemp("", "ygg_rex")
 	if err != nil {
 		reportStartError(fmt.Sprintf("failed to create script tmp file: %v", err), updates)
 		return


### PR DESCRIPTION
This replaces the (as of Go 1.17) deprecated [ioutil.TempFile](https://pkg.go.dev/io/ioutil#TempFile) with [os.CreateTemp](https://pkg.go.dev/os#CreateTemp). When calling `os.CreateTemp` with an empty `dir` the default directory for temporary files is used. On UNIX that's `$TMPDIR` if non-empty or `/tmp`.