### PR TITLE
Drop Go 1.15 & 1.17 and add 1.19 & 1.20

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ['1.15', '1.16', '1.17']
+        go:
+          - '1.16'
+          - '1.19'
+          - '1.20'
     steps:
       - uses: actions/checkout@v2
 
@@ -44,4 +47,4 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2.5.1
         with:
-          args: --go=1.15
+          args: --go=1.16

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
           - '1.19'
           - '1.20'
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup go
         uses: actions/setup-go@v2
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v2.5.1
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Setup go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -44,7 +44,9 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3
-      - name: Run golangci-lint
-        uses: golangci/golangci-lint-action@v2.5.1
+      - name: Setup go
+        uses: actions/setup-go@v4
         with:
-          args: --go=1.16
+          go-version: '1.16'
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v3


### PR DESCRIPTION
In EPEL7 there's Go 1.19 while EL8 has Go 1.20. Red Hat Satellite still uses Go 1.16 so that remains in the matrix for now.